### PR TITLE
fix: open soundfile's path

### DIFF
--- a/PolyBuf.sc
+++ b/PolyBuf.sc
@@ -73,7 +73,7 @@ BufFiles {
 		// arg and select the files that seem to be audio files
         path = if(path.class != PathName, {PathName(path)}, { path });
 		paths = path.files.select({|soundfile|
-			this.checkHeader(soundfile.fullPath)
+			this.checkHeader(soundfile)
 		});
         folderName = path.fileName.postln;
 


### PR DESCRIPTION
to prevent `.extension` in `checkHeader` to throw en errors when initializing `BufFiles`. so I removed `.fullPath` from `soundfile` since it return `String`.

related issue: https://github.com/madskjeldgaard/PolyBuf/commit/874a1afe1ca934a85d8f78ab601f1317bc5699d3